### PR TITLE
If the file starts with null bytes then skip it

### DIFF
--- a/src/verifyUSFM.py
+++ b/src/verifyUSFM.py
@@ -1232,16 +1232,16 @@ def verifyFile(path):
     with io.open(path, "r", encoding="utf-8-sig") as input:
         contents = input.read(-1)
 
-    if len(contents) > 5 and contents[:5] == '\x00\x00\x00\x00\x00':
-        reportError("File is most likely null " + shortname(path), 82)
-        return
-
     if wjwj_re.search(contents):
         reportError("Empty \\wj \\wj* pair(s) in " + shortname(path), 77)
     if backslasheol_re.search(contents):
         reportError("Stranded backslash(es) at end of line(s) in " + shortname(path), 78)
     if '\x00' in contents:
         reportError("Null bytes found in " + shortname(path), 79)
+        if contents.count('\x00') == len(contents):
+            reportError("File is entirely null bytes: " + shortname(path), 79.1)
+            return
+
     aligned_usfm = ("lemma=" in contents or "x-occurrences" in contents)
     if aligned_usfm:
         contents = usfm_utils.unalign_usfm(contents)

--- a/src/verifyUSFM.py
+++ b/src/verifyUSFM.py
@@ -1232,6 +1232,10 @@ def verifyFile(path):
     with io.open(path, "r", encoding="utf-8-sig") as input:
         contents = input.read(-1)
 
+    if len(contents) > 5 and contents[:5] == '\x00\x00\x00\x00\x00':
+        reportError("File is most likely null " + shortname(path), 82)
+        return
+
     if wjwj_re.search(contents):
         reportError("Empty \\wj \\wj* pair(s) in " + shortname(path), 77)
     if backslasheol_re.search(contents):


### PR DESCRIPTION
We've run into an odd case where a repo has a file that is full of null bytes, it has size but no data, most likely a corrupted file. This checks for that and then skips the rest of the checks. An example of this is https://content.bibletranslationtools.org/DCS-Mirror/Suresh_Chandra_en-textTranslation-braj_Bhasha_Bible/src/branch/scribe-main/ingredients/ACT.usfm